### PR TITLE
feat(app): 105 Collision event

### DIFF
--- a/docs/components/collider.md
+++ b/docs/components/collider.md
@@ -1,4 +1,18 @@
-# Collider
+# Custom Colliders
+
+## Collisions
+
+Similar to [how collisions work in rigid-bodies](./rigid-body.md#collisions) you can set a custom collider to receive collisions events.
+
+Be aware that the event will be emitted by the `RigidBody` parent
+
+```html
+...
+<RigidBody @collision-enter="onCollisionEnter" @collision-exit="onCollisionExit">
+  <BallCollider activeCollision />
+</RigidBody>
+...
+```
 
 ## Props
 
@@ -11,6 +25,9 @@
 | **mass**        | Mass of the collider. (automatic-collider)                                                                    | `1`       |
 | **density**     | Restitution controls how elastic (aka. bouncy) a contact is. (automatic-collider)                             | `0`       |
 | **restitution** | The collider density. If non-zero the collider's mass and angular inertia will be added. (automatic-collider) | `1`       |
+| **activeCollision**      | To set the collider receiver/emitter collision events                                                                    | `false`                            |
+| **activeCollisionTypes** | Type of the collision event.                                                                    | `ActiveCollisionTypes.DEFAULT`                            |
+| **collisionGroups**      | To specify collision groups.                                                                    | `undefined`                            |
 
 :::info
 You can access the [Collider](https://rapier.rs/docs/user_guides/javascript/colliders) instance

--- a/docs/components/rigid-body.md
+++ b/docs/components/rigid-body.md
@@ -1,11 +1,9 @@
 # RigidBody
 
-:::info
-The information in this page is a summary of the RigidBody instance,
+:::info The information in this page is a summary of the RigidBody instance,
 please check the
 [complete documentation](https://rapier.rs/docs/user_guides/javascript/rigid_bodies)
-for more info
-:::
+for more info :::
 
 The real-time simulation of rigid-bodies subjected to forces and contacts is the
 main feature of a physics engine for video-games, robotics, or animation.
@@ -54,11 +52,9 @@ A basic floor example with type fixed:
 | `KinematicPositionBased` | Indicates that the body position must not be altered by the physics engine.                                  |
 | `KinematicVelocityBased` | Indicates that the body velocity must not be altered by the physics engine.                                  |
 
-:::info
-Both position-based and velocity-based kinematic bodies are mostly the
+:::info Both position-based and velocity-based kinematic bodies are mostly the
 same. Choosing between both is mostly a matter of preference between
-position-based control and velocity-based control.
-:::
+position-based control and velocity-based control. :::
 
 More info at
 [Rigid-body type](https://rapier.rs/docs/user_guides/javascript/rigid_bodies#rigid-body-type)
@@ -129,36 +125,68 @@ More info
 
 ## Collisions
 
+To start receiving collisions events, first you need to set the
+`active-collision` prop to our `RigidBody` (this set all our automatic
+colliders). Then you can start listening for events in `@collision-enter` and/or
+`@collision-exit`.
+
+```html
+...
+<RigidBody activeCollision @collision-enter="onCollisionEnter" @collision-exit="onCollisionExit">
+  <TresMesh>
+    <TresBoxGeometry />
+    <TresMeshNormalMaterial />
+  </TresMesh>
+</RigidBody>
+...
+```
+
+- You can set continuous collision detection for fast moving object, passing as a
+prop `enableCcd`.
+- You can specify the collision type using
+`activeCollisionTypes` props.
+- Also you can set specific collision groups by
+using the `collisionGroups` prop.
+
+## Sensor
+
 SOON
 
-## Events
+## Contact force
+
+SOON
+
+## Sleep/awake
 
 SOON
 
 ## Props
 
-| Prop                    | Description                                                                                                   | Default                        |
-| :---------------------- | :------------------------------------------------------------------------------------------------------------ | ------------------------------ |
-| **type**                | `rigidBody` type                                                                                              | `dynamic`                      |
-| **collider**            | automatic collider                                                                                            | `cuboid`                       |
-| **gravityScale**        | gravity for the `rigidBody`                                                                                   | `1`                            |
-| **additionalMass**      | add extra mass to the `rigidBody`                                                                             | `0`                            |
-| **linearDamping**       | set the linear damping                                                                                        | `0`                            |
-| **angularDamping**      | set the angular damping                                                                                       | `0`                            |
-| **dominanceGroup**      | set the dominance group                                                                                       | `0`                            |
-| **linvel**              | linear velocity                                                                                               | `x: 0, y: 0, z: 0`             |
-| **angvel**              | angular velocity                                                                                              | `x: 0, y: 0, z: 0`             |
-| **enabledRotations**    | enable rotations in specific axis                                                                             | `{x: true, y: true, z: true }` |
-| **enabledTranslations** | enable translations in specific axis                                                                          | `{x: true, y: true, z: true }` |
-| **lockTranslations**    | Lock all translations                                                                                         | `false`                        |
-| **lockRotations**       | Lock all rotations                                                                                            | `false`                        |
-| **friction**            | The friction coefficient of this collider. (automatic-collider)                                               | `0.5`                          |
-| **mass**                | Mass of the collider. (automatic-collider)                                                                    | `1`                            |
-| **density**             | Restitution controls how elastic (aka. bouncy) a contact is. (automatic-collider)                             | `0`                            |
-| **restitution**         | The collider density. If non-zero the collider's mass and angular inertia will be added. (automatic-collider) | `1`                            |
+| Prop                     | Description                                                                                                   | Default                        |
+| :----------------------- | :------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| **type**                 | `rigidBody` type                                                                                              | `dynamic`                      |
+| **collider**             | automatic collider                                                                                            | `cuboid`                       |
+| **gravityScale**         | gravity for the `rigidBody`                                                                                   | `1`                            |
+| **additionalMass**       | add extra mass to the `rigidBody`                                                                             | `0`                            |
+| **linearDamping**        | set the linear damping                                                                                        | `0`                            |
+| **angularDamping**       | set the angular damping                                                                                       | `0`                            |
+| **dominanceGroup**       | set the dominance group                                                                                       | `0`                            |
+| **linvel**               | linear velocity                                                                                               | `x: 0, y: 0, z: 0`             |
+| **angvel**               | angular velocity                                                                                              | `x: 0, y: 0, z: 0`             |
+| **enabledRotations**     | enable rotations in specific axis                                                                             | `{x: true, y: true, z: true }` |
+| **enabledTranslations**  | enable translations in specific axis                                                                          | `{x: true, y: true, z: true }` |
+| **lockTranslations**     | Lock all translations                                                                                         | `false`                        |
+| **lockRotations**        | Lock all rotations                                                                                            | `false`                        |
+| **enableCcd**        | Enable continuous collision detection                                                                                            | `false`                        |
+| **friction**             | The friction coefficient of this collider. (automatic-collider)                                               | `0.5`                          |
+| **mass**                 | Mass of the collider. (automatic-collider)                                                                    | `1`                            |
+| **density**              | Restitution controls how elastic (aka. bouncy) a contact is. (automatic-collider)                             | `0`                            |
+| **restitution**          | The collider density. If non-zero the collider's mass and angular inertia will be added. (automatic-collider) | `1`                            |
+| **activeCollision**      | To set the collider receiver/emitter collision events (automatic-collider)                                                                    | `false`                            |
+| **activeCollisionTypes** | Type of the collision event. (automatic-collider)                                                                    | `ActiveCollisionTypes.DEFAULT`                            |
+| **collisionGroups**      | To specify collision groups. (automatic-collider)                                                                    | `undefined`                            |
 
-:::info
-The `rigidBody` instance has many other functions, please check the
+:::info The `rigidBody` instance has many other functions, please check the
 [official docs](https://rapier.rs/docs/api/javascript/JavaScript3D/) for a
 complete list, if you need them, you can
 use[Template ref](https://vuejs.org/guide/essentials/template-refs.html#template-refs).

--- a/playground/src/pages/basics/CollisionDemo.vue
+++ b/playground/src/pages/basics/CollisionDemo.vue
@@ -14,15 +14,10 @@ const gl = {
 }
 
 const rigidTorusRef = shallowRef()
-const ballRef = shallowRef()
 
 const jump = () => {
   if (!rigidTorusRef.value) { return }
   rigidTorusRef.value.instance.applyImpulse({ x: 0, y: 5, z: 0 }, true)
-}
-const jumpBall = () => {
-  if (!ballRef.value) { return }
-  ballRef.value.instance.applyImpulse({ x: 0, y: 5, z: 0 }, true)
 }
 
 const onCollisionEnter = (event: any) => {
@@ -68,11 +63,9 @@ const onCollisionExit = (event: any) => {
           @collision-enter="onCollisionEnterBall"
         >
           <BallCollider
-            ref="ballRef"
             activeCollision
             :args="[1, 1, 1]"
             :position="[8, 15, 0]"
-            @click="jumpBall"
           />
         </RigidBody>
 

--- a/playground/src/pages/basics/CollisionDemo.vue
+++ b/playground/src/pages/basics/CollisionDemo.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { OrbitControls } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
+import { BallCollider, Physics, RigidBody } from '@tresjs/rapier'
+import { ACESFilmicToneMapping, SRGBColorSpace } from 'three'
+import { shallowRef } from 'vue'
+
+const gl = {
+  clearColor: '#82DBC5',
+  shadows: true,
+  alpha: false,
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: ACESFilmicToneMapping,
+}
+
+const rigidTorusRef = shallowRef()
+const ballRef = shallowRef()
+
+const jump = () => {
+  if (!rigidTorusRef.value) { return }
+  rigidTorusRef.value.instance.applyImpulse({ x: 0, y: 5, z: 0 }, true)
+}
+const jumpBall = () => {
+  if (!ballRef.value) { return }
+  ballRef.value.instance.applyImpulse({ x: 0, y: 5, z: 0 }, true)
+}
+
+const onCollisionEnter = (event: any) => {
+  // eslint-disable-next-line no-console
+  console.log('jaime ~ ENTER', event)
+}
+const onCollisionEnterBall = (event: any) => {
+  // eslint-disable-next-line no-console
+  console.log('jaime ~ ENTER', event.source.rapierGroup.collider.collisionGroups())
+}
+const onCollisionExit = (event: any) => {
+  // eslint-disable-next-line no-console
+  console.log('jaime ~ EXIT', event)
+}
+</script>
+
+<template>
+  <TresCanvas v-bind="gl" window-size>
+    <TresPerspectiveCamera :position="[0, 11, 30]" :look-at="[0, 0, 0]" />
+    <OrbitControls />
+
+    <Suspense>
+      <Physics debug>
+        <RigidBody
+          ref="rigidTorusRef"
+          name="rigidTorus"
+          enableCcd
+          activeCollision
+          @collision-enter="onCollisionEnter"
+          @collision-exit="onCollisionExit"
+        >
+          <TresMesh :position="[0, 8, 0]" @click="jump">
+            <TresTorusGeometry />
+            <TresMeshNormalMaterial />
+          </TresMesh>
+          <TresMesh :position="[-5, 7, 0]">
+            <TresSphereGeometry />
+            <TresMeshNormalMaterial />
+          </TresMesh>
+        </RigidBody>
+
+        <RigidBody
+          @collision-enter="onCollisionEnterBall"
+        >
+          <BallCollider
+            ref="ballRef"
+            activeCollision
+            :args="[1, 1, 1]"
+            :position="[8, 15, 0]"
+            @click="jumpBall"
+          />
+        </RigidBody>
+
+        <RigidBody type="fixed" name="fixedFloor">
+          <TresMesh :position="[0, 0, 0]">
+            <TresPlaneGeometry :args="[20, 20, 20]" :rotate-x="-Math.PI / 2" />
+            <TresMeshBasicMaterial color="#f4f4f4" />
+          </TresMesh>
+        </RigidBody>
+      </Physics>
+    </Suspense>
+  </TresCanvas>
+</template>

--- a/playground/src/router/routes/basics.ts
+++ b/playground/src/router/routes/basics.ts
@@ -29,4 +29,9 @@ export const basicsRoutes = [
     name: 'Props',
     component: () => import('../../pages/basics/RigidBodyProps.vue'),
   },
+  {
+    path: '/basics/collision',
+    name: 'Collision',
+    component: () => import('../../pages/basics/CollisionDemo.vue'),
+  },
 ]

--- a/src/components/Physics.vue
+++ b/src/components/Physics.vue
@@ -7,7 +7,7 @@ import type { VectorCoordinates } from '@tresjs/core'
 import { useRapierContextProvider } from '../composables/useRapier'
 import { GRAVITY } from '../constants/physics'
 
-import { collisionEmisor, get3DGroupFromSource, getSourceFromColliderHandle } from '../utils/collisions'
+import { collisionEmisor, get3DGroupFromSource, getSourceFromColliderHandle } from '../utils'
 import Debug from './Debug.vue'
 import type { PhysicsProps } from '../types'
 

--- a/src/components/Physics.vue
+++ b/src/components/Physics.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { useLoop } from '@tresjs/core'
+import { EventQueue } from '@dimforge/rapier3d-compat'
+import { useLoop, useTresContext } from '@tresjs/core'
 import { Vector3 } from 'three'
 import { watch } from 'vue'
 import type { VectorCoordinates } from '@tresjs/core'
 import { useRapierContextProvider } from '../composables/useRapier'
-
 import { GRAVITY } from '../constants/physics'
+
+import { collisionEmisor, get3DGroupFromSource, getSourceFromColliderHandle } from '../utils/collisions'
 import Debug from './Debug.vue'
 import type { PhysicsProps } from '../types'
 
@@ -34,6 +36,9 @@ const setGravity = (gravity: PhysicsProps['gravity']) => {
   }
 }
 
+const eventQueue = new EventQueue(true)
+const { scene } = useTresContext()
+
 watch(() => props.gravity, (gravity) => {
   setGravity(gravity)
 }, { immediate: true })
@@ -46,7 +51,20 @@ onBeforeRender(() => {
     world.timestep = props.timestep
   }
 
-  world.step()
+  world.step(eventQueue)
+  eventQueue.drainCollisionEvents((handle1, handle2, started) => {
+    const source1 = getSourceFromColliderHandle(world, handle1)
+    const source2 = getSourceFromColliderHandle(world, handle2)
+    const group1 = get3DGroupFromSource(source1, scene)
+    const group2 = get3DGroupFromSource(source2, scene)
+    if (group1 && group2) {
+      collisionEmisor(
+        { group: group1, rapierGroup: source1 },
+        { group: group2, rapierGroup: source2 },
+        started,
+      )
+    }
+  })
 })
 </script>
 

--- a/src/components/Physics.vue
+++ b/src/components/Physics.vue
@@ -59,8 +59,8 @@ onBeforeRender(() => {
     const group2 = get3DGroupFromSource(source2, scene)
     if (group1 && group2) {
       collisionEmisor(
-        { group: group1, rapierGroup: source1 },
-        { group: group2, rapierGroup: source2 },
+        { object: group1, context: source1 },
+        { object: group2, context: source2 },
         started,
       )
     }

--- a/src/components/RigidBody.vue
+++ b/src/components/RigidBody.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ActiveCollisionTypes } from '@dimforge/rapier3d-compat'
 import { useLoop } from '@tresjs/core'
 import { Object3D } from 'three'
 import { nextTick, onUnmounted, onUpdated, provide, shallowRef, watch } from 'vue'
@@ -24,12 +25,15 @@ const props = withDefaults(defineProps<Partial<RigidBodyProps>>(), {
   enabledTranslations: () => ({ x: true, y: true, z: true }),
   lockTranslations: false,
   lockRotations: false,
+  enableCcd: false,
   // Automatic collider props
   friction: 0.5,
   mass: 1,
   restitution: 0,
   density: 1,
-
+  activeCollision: false,
+  activeCollisionTypes: ActiveCollisionTypes.DEFAULT,
+  collisionGroups: undefined, // this is not working
 })
 const { onBeforeRender } = useLoop()
 const { world } = useRapierContext()
@@ -101,6 +105,10 @@ watch([() => props.lockRotations, instance], ([_lockRotations, _]) => {
   if (!instance.value) { return }
   instance.value.lockRotations(_lockRotations, true)
 })
+watch([() => props.enableCcd, instance], ([_enableCcd, _]) => {
+  if (!instance.value) { return }
+  instance.value.enableCcd(_enableCcd)
+})
 
 onBeforeRender(() => {
   const context = bodyContext.value
@@ -142,6 +150,9 @@ onUnmounted(() => {
       :mass="props.mass"
       :restitution="props.restitution"
       :density="props.density"
+      :activeCollision="props.activeCollision"
+      :activeCollisionTypes="activeCollisionTypes"
+      :collisionGroups="collisionGroups"
     />
     <slot v-once></slot>
   </TresGroup>

--- a/src/components/colliders/BaseCollider.vue
+++ b/src/components/colliders/BaseCollider.vue
@@ -61,6 +61,11 @@ watch(bodyContext, async (state) => {
 // TODO: collisionGroups
 makePropsWatcherCL(props, ['friction', 'restitution', 'density', 'mass', 'activeCollisionTypes'], colliderInfos)
 
+watch([() => props.collisionGroups, colliderInfos], ([_collisionGroups, _]) => {
+  if (!colliderInfos.value?.collider || !_collisionGroups) { return }
+  colliderInfos.value.collider.setCollisionGroups(_collisionGroups)
+})
+
 watch([() => props.activeCollision, colliderInfos], ([_activeCollision]) => {
   if (!colliderInfos.value?.collider) { return }
   if (_activeCollision) {

--- a/src/components/colliders/BaseCollider.vue
+++ b/src/components/colliders/BaseCollider.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { inject, nextTick, onUnmounted, type ShallowRef, shallowRef, watch } from 'vue'
+import { ActiveCollisionTypes, ActiveEvents } from '@dimforge/rapier3d-compat'
 
+import { inject, nextTick, onUnmounted, type ShallowRef, shallowRef, watch } from 'vue'
 import { useRapierContext } from '../../composables'
 import { createCollider } from '../../core/collider'
 import { makePropsWatcherCL } from '../../utils/props'
@@ -13,6 +14,9 @@ const props = withDefaults(defineProps<Partial<ColliderProps>>(), {
   mass: 1,
   restitution: 0,
   density: 1,
+  activeCollision: false,
+  activeCollisionTypes: ActiveCollisionTypes.DEFAULT,
+  collisionGroups: undefined,
 })
 
 const { world } = useRapierContext()
@@ -54,7 +58,18 @@ watch(bodyContext, async (state) => {
   state.colliders.push(infos)
 }, { immediate: true })
 
-makePropsWatcherCL(props, ['friction', 'restitution', 'density', 'mass'], colliderInfos)
+// TODO: collisionGroups
+makePropsWatcherCL(props, ['friction', 'restitution', 'density', 'mass', 'activeCollisionTypes'], colliderInfos)
+
+watch([() => props.activeCollision, colliderInfos], ([_activeCollision]) => {
+  if (!colliderInfos.value?.collider) { return }
+  if (_activeCollision) {
+    colliderInfos.value.collider.setActiveEvents(ActiveEvents.COLLISION_EVENTS)
+  }
+  else {
+    colliderInfos.value.collider.setActiveEvents(ActiveEvents.NONE)
+  }
+})
 
 onUnmounted(() => {
   if (!bodyContext.value || !colliderInfos.value?.collider) { return }

--- a/src/types/collider.ts
+++ b/src/types/collider.ts
@@ -79,9 +79,9 @@ export interface ColliderProps {
    */
   activeCollisionTypes?: ActiveCollisionTypes.DEFAULT
   /**
- * @description To set the collision group.
- * @default undefined
-*/
+   * @description To set the collision group.
+   * @default undefined
+   */
   collisionGroups?: undefined | number
 }
 

--- a/src/types/collider.ts
+++ b/src/types/collider.ts
@@ -1,4 +1,5 @@
 import type {
+  ActiveCollisionTypes,
   Collider,
   ColliderDesc,
   RigidBody,
@@ -67,6 +68,21 @@ export interface ColliderProps {
    * @default 1.0
    */
   density?: number
+  /**
+   * @description Enables collisions event.
+   * @default false
+   */
+  activeCollision?: boolean
+  /**
+   * @description To set the collision type.
+   * @default ActiveCollisionTypes.DEFAULT
+   */
+  activeCollisionTypes?: ActiveCollisionTypes.DEFAULT
+  /**
+ * @description To set the collision group.
+ * @default undefined
+*/
+  collisionGroups?: undefined | number
 }
 
 export interface ExposedCollider {

--- a/src/types/collision.ts
+++ b/src/types/collision.ts
@@ -1,0 +1,14 @@
+import type { Collider, RigidBody } from '@dimforge/rapier3d-compat'
+import type { Object3D } from 'three'
+
+export interface CollisionSource {
+  collider: Collider
+  rigidBody: RigidBody | undefined
+};
+
+export interface sourceTarget {
+  group: Object3D
+  rapierGroup: CollisionSource
+}
+
+export type collisionType = 'enter' | 'exit'

--- a/src/types/collision.ts
+++ b/src/types/collision.ts
@@ -7,8 +7,8 @@ export interface CollisionSource {
 };
 
 export interface sourceTarget {
-  group: Object3D
-  rapierGroup: CollisionSource
+  object: Object3D
+  context: CollisionSource
 }
 
 export type collisionType = 'enter' | 'exit'

--- a/src/types/rigid-body.ts
+++ b/src/types/rigid-body.ts
@@ -1,4 +1,4 @@
-import type { Collider, ColliderDesc, RigidBody, RigidBodyDesc, World } from '@dimforge/rapier3d-compat'
+import type { ActiveCollisionTypes, Collider, ColliderDesc, RigidBody, RigidBodyDesc, World } from '@dimforge/rapier3d-compat'
 import type { TresObject3D, TresVector3, VectorCoordinates } from '@tresjs/core'
 
 import type { enableBolean } from './boolean'
@@ -76,29 +76,50 @@ export interface RigidBodyProps {
    * @default false
    */
   lockRotations?: boolean
+  /**
+   * @description Enables continuous collisions detection.
+   * @default false
+   */
+  enableCcd?: boolean
 
   // AUTOMATIC COLLIDERS
 
   /**
    * @description The friction coefficient of this collider.
    * @default 0.5
-   */
+  */
   friction?: number
   /**
-   * @description mass.
-   * @default 1
-   */
+  * @description mass.
+  * @default 1
+ */
   mass?: number
   /**
-   * @description Restitution controls how elastic (aka. bouncy) a contact is.
-   * @default 0
-   */
+ * @description Restitution controls how elastic (aka. bouncy) a contact is.
+ * @default 0
+*/
   restitution?: number
   /**
-   * @description The collider density. If non-zero the collider's mass and angular inertia will be added.
-   * @default 1.0
-   */
+ * @description The collider density. If non-zero the collider's mass and angular inertia will be added.
+ * @default 1.0
+*/
   density?: number
+  /**
+ * @description Enables collisions event.
+ * @default false
+ */
+  activeCollision?: boolean
+  /**
+ * @description To set the collision type.
+ * @default ActiveCollisionTypes.DEFAULT
+*/
+  activeCollisionTypes?: ActiveCollisionTypes.DEFAULT
+  /**
+ * @description To set the collision group.
+ * @default undefined
+*/
+  collisionGroups?: undefined | number
+
 }
 
 export interface ExposedRigidBody {

--- a/src/types/rigid-body.ts
+++ b/src/types/rigid-body.ts
@@ -87,37 +87,37 @@ export interface RigidBodyProps {
   /**
    * @description The friction coefficient of this collider.
    * @default 0.5
-  */
+   */
   friction?: number
   /**
-  * @description mass.
-  * @default 1
- */
+   * @description mass.
+   * @default 1
+   */
   mass?: number
   /**
- * @description Restitution controls how elastic (aka. bouncy) a contact is.
- * @default 0
-*/
+   * @description Restitution controls how elastic (aka. bouncy) a contact is.
+   * @default 0
+   */
   restitution?: number
   /**
- * @description The collider density. If non-zero the collider's mass and angular inertia will be added.
- * @default 1.0
-*/
+   * @description The collider density. If non-zero the collider's mass and angular inertia will be added.
+   * @default 1.0
+   */
   density?: number
   /**
- * @description Enables collisions event.
- * @default false
- */
+   * @description Enables collisions event.
+   * @default false
+   */
   activeCollision?: boolean
   /**
- * @description To set the collision type.
- * @default ActiveCollisionTypes.DEFAULT
-*/
+   * @description To set the collision type.
+   * @default ActiveCollisionTypes.DEFAULT
+   */
   activeCollisionTypes?: ActiveCollisionTypes.DEFAULT
   /**
- * @description To set the collision group.
- * @default undefined
-*/
+   * @description To set the collision group.
+   * @default undefined
+   */
   collisionGroups?: undefined | number
 
 }

--- a/src/utils/collisions.ts
+++ b/src/utils/collisions.ts
@@ -1,16 +1,7 @@
-import type { Collider, ColliderHandle, RigidBody, World } from '@dimforge/rapier3d-compat'
-import type { Group, Scene } from 'three'
+import type { ColliderHandle, World } from '@dimforge/rapier3d-compat'
+import type { Scene } from 'three'
 import type { Ref } from 'vue'
-
-interface CollisionSource {
-  collider: Collider
-  rigidBody: RigidBody | undefined
-};
-
-interface sourceTarget {
-  group: Group
-  rapierGroup: CollisionSource
-}
+import type { CollisionSource, collisionType, sourceTarget } from '../types/collision'
 
 export const getSourceFromColliderHandle = (world: World, handle: ColliderHandle) => {
   const collider = world.getCollider(handle)
@@ -39,6 +30,6 @@ export const collisionEmisor = (
   target: sourceTarget,
   started: boolean,
 ) => {
-  const collisionType = started ? 'enter' : 'exit'
-  source.group?.__vnode?.ctx.emit(`collision-${collisionType}`, { source, target })
+  const collisionType: collisionType = started ? 'enter' : 'exit';
+  (source.group as any)?.__vnode?.ctx?.emit?.(`collision-${collisionType}`, { source, target })
 }

--- a/src/utils/collisions.ts
+++ b/src/utils/collisions.ts
@@ -1,0 +1,44 @@
+import type { Collider, ColliderHandle, RigidBody, World } from '@dimforge/rapier3d-compat'
+import type { Group, Scene } from 'three'
+import type { Ref } from 'vue'
+
+interface CollisionSource {
+  collider: Collider
+  rigidBody: RigidBody | undefined
+};
+
+interface sourceTarget {
+  group: Group
+  rapierGroup: CollisionSource
+}
+
+export const getSourceFromColliderHandle = (world: World, handle: ColliderHandle) => {
+  const collider = world.getCollider(handle)
+  const rigidBodyHandle = collider?.parent()?.handle
+  const rigidBody
+  = rigidBodyHandle !== undefined
+    ? world.getRigidBody(rigidBodyHandle)
+    : undefined
+  const source: CollisionSource = {
+    collider,
+    rigidBody,
+  }
+
+  return source
+}
+
+export const get3DGroupFromSource = (source: CollisionSource, scene: Ref<Scene>) => {
+  const uuid = (source.rigidBody?.userData as { uuid?: string })?.uuid
+  const currentRigidBodyNode = scene.value.getObjectByProperty('uuid', uuid)
+
+  return currentRigidBodyNode
+}
+
+export const collisionEmisor = (
+  source: sourceTarget,
+  target: sourceTarget,
+  started: boolean,
+) => {
+  const collisionType = started ? 'enter' : 'exit'
+  source.group?.__vnode?.ctx.emit(`collision-${collisionType}`, { source, target })
+}

--- a/src/utils/collisions.ts
+++ b/src/utils/collisions.ts
@@ -31,5 +31,5 @@ export const collisionEmisor = (
   started: boolean,
 ) => {
   const collisionType: collisionType = started ? 'enter' : 'exit';
-  (source.group as any)?.__vnode?.ctx?.emit?.(`collision-${collisionType}`, { source, target })
+  (source.object as any)?.__vnode?.ctx?.emit?.(`collision-${collisionType}`, { source, target })
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './collider'
+export * from './collisions'


### PR DESCRIPTION
closes #105 

This is the draft version my friend, if you want you can start to check it out.

Currently, docs are missing, I need to clean some types, and figure out how to handle the collision groups.

I took some design decision about this API:

1. I add an optional prop `activeCollision` to the colliders and rigidBody components in order to set the Collision event (necessary step for all the process). But I got some considerations, what about other events?, should this be true by default? is this props unnecessary
2. I'm using emits in order to send the events to the user (I loved this because is a Vuesh feature) but this mean the event is only trigger when the collision appears (not in the renderLoop, of course this could be handled by the user)
3. The event queue is always true in the physic component, I think this is the right thing to do, since other events are needed but for now if you don't use the collision is useless.