### PR TITLE
fix(core): use array instead of boolean object

### DIFF
--- a/src/types/boolean.ts
+++ b/src/types/boolean.ts
@@ -1,1 +1,0 @@
-export interface enableBolean { x: boolean, y: boolean, z: boolean }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
-export * from './boolean'
 export * from './collider'
+export * from './collision'
 export * from './object'
 export * from './physics'
 export * from './rapier'

--- a/src/types/rigid-body.ts
+++ b/src/types/rigid-body.ts
@@ -1,7 +1,6 @@
 import type { ActiveCollisionTypes, Collider, ColliderDesc, RigidBody, RigidBodyDesc, World } from '@dimforge/rapier3d-compat'
 import type { TresObject3D, TresVector3, VectorCoordinates } from '@tresjs/core'
 
-import type { enableBolean } from './boolean'
 import type { ColliderShape } from './collider'
 
 /** @description Tres Rapier supported `RigidBody` types. */
@@ -58,14 +57,14 @@ export interface RigidBodyProps {
   dominanceGroup?: number
   /**
    * @description Set the dominance group of the`RigidBody`.
-   * @default { x: true, y: true, z: true }
+   * @default [true,true,true]
    */
-  enabledRotations?: enableBolean
+  enabledRotations?: [x: boolean, y: boolean, z: boolean]
   /**
    * @description Set the dominance group of the`RigidBody`.
-   * @default { x: true, y: true, z: true }
+   * @default [true,true,true]
    */
-  enableTranslations?: enableBolean
+  enabledTranslations?: [x: boolean, y: boolean, z: boolean]
   /**
    * @description Locks the translations of the `RigidBody`.
    * @default false

--- a/src/utils/props.ts
+++ b/src/utils/props.ts
@@ -1,18 +1,26 @@
 import { watch } from 'vue'
 import type { RigidBody } from '@dimforge/rapier3d-compat'
 import type { ShallowRef } from 'vue'
-import type { CallableProps, ColliderProps, CreateColliderReturnType, Methods, RigidBodyContext, RigidBodyProps } from '../types'
+import type {
+  CallableProps,
+  ColliderProps,
+  CreateColliderReturnType,
+  Methods,
+  RigidBodyContext,
+  RigidBodyProps,
+} from '../types'
 
 export const makePropWatcherRB = <
   K extends keyof RigidBodyProps,
 >(
   props: RigidBodyProps,
   toWatch: K,
-  instance: ShallowRef<RigidBodyContext['rigidBody']>,
+  instance: ShallowRef<RigidBodyContext['rigidBody'] | undefined>,
   onSet: `set${Capitalize<keyof RigidBodyProps>}`,
 ) => watch([() => props[toWatch], instance], ([newValue, _]) => {
   if (!instance.value) { return }
-  ((instance.value[onSet as keyof Methods<RigidBody>]) as CallableProps<RigidBody>[keyof CallableProps<RigidBody>])?.(newValue, true)
+  // TODO: we should give users the possibility to set the wakeUp parameter.
+  ((instance.value[onSet as keyof Methods<RigidBody>]) as CallableProps<RigidBody>[keyof CallableProps<RigidBody>])?.(...(Array.isArray(newValue) ? (newValue as boolean[]) : [newValue]), true)
 })
 
 export const makePropsWatcherRB = <
@@ -20,7 +28,7 @@ export const makePropsWatcherRB = <
 >(
   props: RigidBodyProps,
   watchers: K[],
-  instance: ShallowRef<RigidBodyContext['rigidBody']>,
+  instance: ShallowRef<RigidBodyContext['rigidBody'] | undefined>,
 ) => watchers.forEach((_) => {
   const watcher = _ as string
   // Uppercase only for the first letter in the watcher


### PR DESCRIPTION
### Description

- Remove boolean types support
- Use a boolean array as the type for `enabled` functions