### PR TITLE
chore(config): register VsCode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist-ssr
 
 # Editor directories and files
 .vscode/*
+!.vscode/settings.json
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,54 @@
+{
+  // Enable the ESlint flat config support
+  "eslint.useFlatConfig": true,
+  "eslint.format.enable": true,
+
+  // Disable the default formatter, use eslint instead
+  "prettier.enable": false,
+  "editor.formatOnSave": false,
+
+  // Auto fix
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "never"
+  },
+
+  // Silent the stylistic rules in you IDE, but still auto fix them
+  "eslint.rules.customizations": [
+    { "rule": "style/*", "severity": "off" },
+    { "rule": "format/*", "severity": "off" },
+    { "rule": "*-indent", "severity": "off" },
+    { "rule": "*-spacing", "severity": "off" },
+    { "rule": "*-spaces", "severity": "off" },
+    { "rule": "*-order", "severity": "off" },
+    { "rule": "*-dangle", "severity": "off" },
+    { "rule": "*-newline", "severity": "off" },
+    { "rule": "*quotes", "severity": "off" },
+    { "rule": "*semi", "severity": "off" }
+  ],
+
+  // Enable eslint for all supported languages
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "vue",
+    "html",
+    "markdown",
+    "json",
+    "jsonc",
+    "yaml",
+    "toml",
+    "yml"
+  ],
+
+  // Default formatter configuration
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "[jsonc]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the vs-code settings to the git versioning system, allowing us to use the same share configuration and preventing us from struggling when formatting the code.

> Recently had a chance to share with @alvarosabu, and helped with the settings.
> Note that for VsCode users or editors that support VsCode settings, will get some extension recommendations to allow them to easily format.

### Logs

- Use configs from @alvarosabu
- Set default formatter to `Eslint`

