### PR TITLE
fix: mark rapier3d-compat as external and optimize deps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
           open: true,
         }), */
       ],
-      external: ['three', 'vue', '@tresjs/core'],
+      external: ['three', 'vue', '@tresjs/core', '@dimforge/rapier3d-compat'],
       output: {
         exports: 'named',
         // Provide global variables to use in the UMD build
@@ -61,11 +61,12 @@ export default defineConfig({
           '@tresjs/core': 'TresjsCore',
           'three': 'Three',
           'vue': 'Vue',
+          '@dimforge/rapier3d-compat': 'Rapier3dCompat',
         },
       },
     },
   },
   optimizeDeps: {
-    exclude: ['three', 'vue', '@tresjs/core'],
+    exclude: ['three', 'vue', '@tresjs/core', '@dimforge/rapier3d-compat'],
   },
 })


### PR DESCRIPTION
This PR reduces the bundle size from an outrageous 2000 kb size to --> 20 kB

Before:
![Screenshot 2024-12-12 at 16 46 34](https://github.com/user-attachments/assets/d82e45f7-3e5a-40f6-8eac-8ff74bb96539)

After:

![Screenshot 2024-12-12 at 16 47 12](https://github.com/user-attachments/assets/dce1ea27-86c2-44c0-88a8-e942fa8d5ea6)

